### PR TITLE
pro-5245 fix: prevent empty array payload and PHP 8.2 compatibility

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -33,7 +33,6 @@
     "no_unused_imports": true,
     "lambda_not_used_import": true,
     "logical_operators": true,
-    "mb_str_functions": true,
     "method_chaining_indentation": true,
     "modernize_strpos": true,
     "trailing_comma_in_multiline": true,

--- a/src/DataProviders/OutputBufferingResponseDataProvider.php
+++ b/src/DataProviders/OutputBufferingResponseDataProvider.php
@@ -115,7 +115,7 @@ final readonly class OutputBufferingResponseDataProvider implements ResponseData
             $pos = mb_strpos($header, ':');
             if (false !== $pos) {
                 $key = mb_substr($header, 0, $pos);
-                $value = mb_trim(mb_substr($header, $pos + 1));
+                $value = trim(mb_substr($header, $pos + 1));
                 $data[$key] = $value;
             }
         }

--- a/src/DataProviders/SuperGlobalsRequestDataProvider.php
+++ b/src/DataProviders/SuperGlobalsRequestDataProvider.php
@@ -55,7 +55,7 @@ final readonly class SuperGlobalsRequestDataProvider implements RequestDataProvi
     public function getRequest(): Request
     {
         // Avoid function call if no headers to filter
-        $headers = getallheaders();
+        $headers = getallheaders() ?: [];
         $filteredHeaders = empty($this->excludedHeaders)
             ? $headers
             : HeaderFilter::filter($headers, $this->excludedHeaders);
@@ -139,6 +139,6 @@ final readonly class SuperGlobalsRequestDataProvider implements RequestDataProvi
         $isHttps = ! empty($_SERVER['HTTPS']) && 'off' !== $_SERVER['HTTPS'];
         $protocol = $isHttps ? 'https://' : 'http://';
 
-        return $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        return $protocol . ($_SERVER['HTTP_HOST'] ?? '') . ($_SERVER['REQUEST_URI'] ?? '');
     }
 }

--- a/src/Treblle.php
+++ b/src/Treblle.php
@@ -195,8 +195,8 @@ final class Treblle
      *   - Child process sends data then terminates itself
      *
      * Error Handling:
-     * - Payload building errors: Sends error message to Treblle instead
-     * - Debug OFF: Falls back to error payload, doesn't throw
+     * - Any failure during payload building or encoding aborts transmission silently
+     * - Debug OFF: Returns without sending anything on any failure
      * - Debug ON: Re-throws exceptions for troubleshooting
      *
      * Background Processing Flow:
@@ -214,15 +214,15 @@ final class Treblle
             $payload = $this->buildPayload();
             $payload = json_encode($payload);
 
-            if (false === $payload || mb_strlen($payload) > 2_000_000) {
-                $payload = '{"error": "payload too large or encoding failed in sdk"}';
+            if (false === $payload || '[]' === $payload || mb_strlen($payload) > 2_000_000) {
+                return;
             }
         } catch (Throwable $throwable) {
             if ($this->debug) {
                 throw $throwable;
             }
 
-            $payload = '{"error": "could not convert payload to valid json in sdk"}';
+            return;
         }
 
         if (! function_exists('pcntl_fork') || false === $this->forkProcess) {
@@ -324,36 +324,27 @@ final class Treblle
      *
      * All sensitive fields are masked before inclusion in the payload.
      *
-     * Error Handling:
-     * - Debug OFF: Returns empty array on failure
-     * - Debug ON: Re-throws exceptions for troubleshooting
+     * Any exception thrown by a data provider propagates to the caller (onShutdown),
+     * which handles it according to the debug mode setting.
      *
-     * @return array<string, mixed> The complete payload array, or empty array on failure
-     * @throws Throwable Only in debug mode if an exception occurs during payload building
+     * @return array<string, mixed> The complete payload array
+     * @throws Throwable If any data provider throws during data collection
      */
     private function buildPayload(): array
     {
-        try {
-            return [
-                'api_key' => $this->apiKey,
-                'sdk_token' => $this->sdkToken,
-                'sdk' => $this->name,
-                'version' => $this->version,
-                'data' => new Data(
-                    $this->serverDataProvider->getServer(),
-                    $this->languageDataProvider->getLanguage(),
-                    $this->requestDataProvider->getRequest(),
-                    $this->responseDataProvider->getResponse(),
-                    $this->errorDataProvider->getErrors()
-                ),
-            ];
-        } catch (Throwable $throwable) {
-            if ($this->debug) {
-                throw $throwable;
-            }
-        }
-
-        return [];
+        return [
+            'api_key' => $this->apiKey,
+            'sdk_token' => $this->sdkToken,
+            'sdk' => $this->name,
+            'version' => $this->version,
+            'data' => new Data(
+                $this->serverDataProvider->getServer(),
+                $this->languageDataProvider->getLanguage(),
+                $this->requestDataProvider->getRequest(),
+                $this->responseDataProvider->getResponse(),
+                $this->errorDataProvider->getErrors()
+            ),
+        ];
     }
 
     /**


### PR DESCRIPTION
- Remove silent catch in buildPayload() so exceptions propagate to onShutdown(), eliminating the [] return path that caused the ingress unmarshal error
- onShutdown() now returns early on any failure instead of sending a malformed error payload to Treblle
- Replace mb_trim() (PHP 8.4+) with trim() in response header parsing, fixing a fatal error on PHP 8.2/8.3
- Remove mb_str_functions Pint rule which was silently re-introducing PHP 8.4-only functions on every format run
- Guard getallheaders() against false return with ?: []
- Add null coalescence to HTTP_HOST and REQUEST_URI in URL construction